### PR TITLE
【ニコ動】一部環境下にて動作しない問題を修正

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -2,16 +2,17 @@ import { copyButton } from './functions/copyButton';
 import { initPinP, startPinP } from './functions/pinp';
 import PictureInPictureIcon from './svg/pinpIcon';
 
-window.onload = function() {
-  const TITLE = '[非公式] PinP';
+const TITLE = '[非公式] PinP';
 
-  const fullScreenButton = document.querySelector(
+const checkPinPButton = setInterval(function() {
+  var fullScreenButton = document.querySelector(
     '.ControllerContainer .EnableFullScreenButton, [class^=___addon-controller___] [class^=___fullscreen-button___]'
   );
 
-  if (fullScreenButton) {
+  if (fullScreenButton != null) {
     initPinP();
     // フルスクボタンをコピーしPinPボタンにする
     copyButton(fullScreenButton, TITLE, PictureInPictureIcon, startPinP);
+    clearInterval(checkPinPButton);
   }
-};
+}, 500);

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -2,14 +2,16 @@ import { copyButton } from './functions/copyButton';
 import { initPinP, startPinP } from './functions/pinp';
 import PictureInPictureIcon from './svg/pinpIcon';
 
-const TITLE = '[非公式] PinP';
+window.onload = function() {
+  const TITLE = '[非公式] PinP';
 
-const fullScreenButton = document.querySelector(
-  '.ControllerContainer .EnableFullScreenButton, [class^=___addon-controller___] [class^=___fullscreen-button___]'
-);
+  const fullScreenButton = document.querySelector(
+    '.ControllerContainer .EnableFullScreenButton, [class^=___addon-controller___] [class^=___fullscreen-button___]'
+  );
 
-if (fullScreenButton) {
-  initPinP();
-  // フルスクボタンをコピーしPinPボタンにする
-  copyButton(fullScreenButton, TITLE, PictureInPictureIcon, startPinP);
-}
+  if (fullScreenButton) {
+    initPinP();
+    // フルスクボタンをコピーしPinPボタンにする
+    copyButton(fullScreenButton, TITLE, PictureInPictureIcon, startPinP);
+  }
+};


### PR DESCRIPTION
以下環境下にて動作しない問題を修正しました

## 修正内容
- 一部環境下、一部ブラウザにて、DOMの読み込みよりも先にJSが実行されてしまい、ボタンが作成されない問題

## やったこと
コピー元のフルスクリーンボタンが取得できるまで0.5秒ごとに確認し、確認でき次第ボタンを作成。
ボタン作成以降、0.5秒ごとのチェックは行わないように。

### 懸念点（一応）
これまで通常にボタンが作成できていた環境では、これまでより少しボタンが遅れて作成されます。
他プレイヤーボタンなどの描画より「ほんのちょっとだけ遅いな」程度です