### PR TITLE
Fix/nicolive image

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "nicopinp",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "main": "index.js",
   "author": "ru_shalm <ru_shalm@hazimu.com>",
   "license": "MIT",

--- a/src/functions/pinp.ts
+++ b/src/functions/pinp.ts
@@ -77,9 +77,11 @@ export function handleVideo(): void {
   const supporterCanvas = document.querySelector<HTMLCanvasElement>(
     SUPPORTER_VIEW_CANVAS_SELECTOR,
   );
-  const akashicCanvas = document.querySelector<HTMLCanvasElement>(
+
+  let akashicCanvas = document.querySelector<HTMLCanvasElement>(
     AKASHIC_CANVAS_SELECTOR,
   );
+  const akashicCanvasContext = akashicCanvas?.getContext('2d');
 
   function update() {
     if (!comment || !targetVideo || !context || myId !== uid) {
@@ -149,23 +151,32 @@ export function handleVideo(): void {
 
       // akashic
       if (akashicCanvas) {
-        const size = calcSize(
-          akashicCanvas.width,
-          akashicCanvas.height,
-          canvas.width,
-          canvas.height,
-        );
-        context.drawImage(
-          akashicCanvas,
-          0,
-          0,
-          akashicCanvas.width,
-          akashicCanvas.height,
-          (canvas.width - size.width) / 2,
-          (canvas.height - size.height) / 2,
-          size.width,
-          size.height,
-        );
+        try {
+          // 外部リソースの読み込みによって canvas が汚染されていないかを確認
+          akashicCanvasContext?.getImageData(0, 0, 1, 1);
+
+          const size = calcSize(
+            akashicCanvas.width,
+            akashicCanvas.height,
+            canvas.width,
+            canvas.height,
+          );
+          context.drawImage(
+            akashicCanvas,
+            0,
+            0,
+            akashicCanvas.width,
+            akashicCanvas.height,
+            (canvas.width - size.width) / 2,
+            (canvas.height - size.height) / 2,
+            size.width,
+            size.height,
+          );
+        } catch (e) {
+          // canvas が汚染されている場合は AkashicCanvas をPinP対象から削除
+          console.error(e);
+          akashicCanvas = null;
+        }
       }
 
       // comment

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -1,5 +1,14 @@
+// ニコ生のギフト描画用
+// AkashicのCanvasが汚染されることを防ぐため、必要に応じて自動的に corssOrigin="anonymous" を付与する
 (() => {
-  const cdnNimgJpPattern = /^https:\/\/[^.]+\.cdn\.nimg\.jp\//;
+  const ANONYMOUS_IMAGE_URLS = [
+    // Akashic
+    'https://resource.akashic.coe.nicovideo.jp/',
+    // ギフト
+    'https://ir.cdn.nimg.jp/',
+    // エモーション
+    'https://secure-dcdn.cdn.nimg.jp/',
+  ];
 
   class AutoAnonymousImage extends Image {
     get src() {
@@ -8,13 +17,13 @@
 
     set src(value: string) {
       super.src = value;
-      if (value?.match(cdnNimgJpPattern)) {
+      if (ANONYMOUS_IMAGE_URLS.some((url) => value.startsWith(url))) {
         this.crossOrigin = 'anonymous';
       }
     }
   }
 
   window.Image = new Proxy(window.Image, {
-    construct: (target, args) => new AutoAnonymousImage(...args),
+    construct: (_target, args) => new AutoAnonymousImage(...args),
   });
 })();


### PR DESCRIPTION
- ニコ生でPinPが動かなくなることがある問題
- nsen などの番組が正常に視聴できなくなる問題

の修正です。

## 経緯

nicopipではギフトをPinPに反映するためにAkashicの画面を転写していますが、
Akashic の canvas が 汚染状態（taint）になると、PinP用の画面出力ができなくなります。

そのため、Akashicの画像を読み込んでいそうなドメインに対して
自動的に `crossOrigin = 'anonymous'` を付与するという方法で無理やり回避しています。

その指定方法に漏れ＋付与してはいけないものにも付与してしまっていたことが原因で、上記の問題が発生していました。

## 対応

再度確認し、付与が必要そうな3つのドメインだけを指定するように変更しました。
また、Akashicについてはcanvasの汚染状態を確認するようにし、
汚染状態になった場合はAkashicをPinP対象から外すことで、動作が止まらないようにしました。