### PR TITLE
fix emotion url

### DIFF
--- a/src/inject.ts
+++ b/src/inject.ts
@@ -7,7 +7,7 @@
     // ギフト
     'https://ir.cdn.nimg.jp/',
     // エモーション
-    'https://secure-dcdn.cdn.nimg.jp/',
+    'https://secure-dcdn.cdn.nimg.jp/nicoad/',
   ];
 
   class AutoAnonymousImage extends Image {


### PR DESCRIPTION
#39 の修正。
URLについてドメインだけで判定をしていたが、
他の画像（ユーザーアイコン）を巻き込んでエラーになるケースがあったため、もう少し厳密に指定するように。
エモーションあんまりよくわかってないので漏れあるかも。